### PR TITLE
Require page parameter to be set

### DIFF
--- a/Helper/Generator.php
+++ b/Helper/Generator.php
@@ -163,9 +163,13 @@ class Generator extends \Magento\Framework\App\Helper\AbstractHelper {
         $this->storeManager->setCurrentStore($this->storeId);
 
         $this->count = $this->request->getParam('count', 100);
-        $this->page = $this->request->getParam('page', 1);
+        $this->page = $this->request->getParam('page');
 
-        if($this->page == 0) {
+        if(is_null($this->page)) {
+            throw new \Exception('Page parameter is required.');
+        }
+
+        if($this->page === "0" || $this->page === 0) {
             $this->page = 1;
         }
 


### PR DESCRIPTION
We need this to avoid infinite loop if customer has a redirect that removes the page parameter.