### PR TITLE
Remove setup_version from module.xml

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="SearchSpring_Feed" setup_version="1.1.4"/>
+	<module name="SearchSpring_Feed"/>
 </config>


### PR DESCRIPTION
setup_version in module.xml deprecated
The Module does not use setup scripts so `setup_version` can be safely removed