### PR TITLE
Bugfix: missing category in the hierarchy issue

### DIFF
--- a/Helper/Generator.php
+++ b/Helper/Generator.php
@@ -546,7 +546,10 @@ class Generator extends \Magento\Framework\App\Helper\AbstractHelper
 
     protected function addCategoriesToRecord($product, &$productRecord)
     {
-        $categoryIds = $product->getCategoryIds();
+        $categoryIds = $product->getCategoryCollection()
+            ->addAttributeToFilter('is_active', 1)
+            ->setOrder('path')
+            ->getColumnValues('entity_id');
 
         $categoryNames = [];
         $categoryHierarchy = [];


### PR DESCRIPTION
**Issue:**

There is a case where the category is missing from the hierarchy even when it's active. See an example below:
1. A product is assigned to the 3 categories as below.
![image](https://user-images.githubusercontent.com/13554792/209831242-d58e30a0-a276-4231-952a-082f839e5214.png)

2. The final inactive category (**Mastectomy Bras**) entity id is less than its parent category (**Mastectomy Bras & Camisoles**)
3. When the logic to add categories for that product to the feed, **Root Catalog>Default Category>Clothing>Mastectomy Bras & Camisoles** isn't added to the product hierarchy.

This is because the current logic loops through the inactive category first and within the first loop, the logic also loads its parent category using its path without attaching the hierarchy. When the logic loop through the parent category of the first inactive category, it uses the cached category from the previous load without hierarchy, and because of that the hierarchy for that category is not included in the data feed.

**Proposed solution:**
- Sort the category by path before getting the list of category ids so that the parent category will always be looped before its child categories.
- Only get the active category ids.

Either of the above solutions would fix the issue. My PR implements both of them because it's make the logic to run faster


